### PR TITLE
CIDR range refactoring

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+charset = utf-8
+indent_size = 2
+

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ class IPCIDR {
     let length = end.subtract(start).add(new BigInteger('1'));
     let info = this.getChunkInfo(length, options);
 
-    if(results)  {
+    if (results) {
       Object.assign(results, info);
     }
 
@@ -81,7 +81,49 @@ class IPCIDR {
 
     return list;
   }
-  
+
+  toRefactoredArray(allowed = null, options = {}) {
+    if (!allowed) {
+      return this.formatIP(this.cidr, options);
+    }
+
+    if (allowed.indexOf(32) === -1) allowed.push(32);
+    allowed = allowed.sort((a, b) => (a - b)).reverse();
+
+    const all = this.toArray();
+    const list = [];
+    while (all.length) {
+
+      let mask = 32;
+      let decimal = 1;
+
+      const allowedCopy = JSON.parse(JSON.stringify(allowed));
+      while (allowedCopy.length) {
+        const maxMask = allowedCopy.pop();
+        const maxDecimal = Math.pow(2, 32 - maxMask);
+
+        if (all.length >= maxDecimal) {
+          decimal = maxDecimal;
+          mask = maxMask;
+          break;
+        }
+      }
+
+      if (Object.keys(options).length) {
+        const cidr = `${all[0]}/${mask}`;
+        let ipAddressType = cidr.match(":") ? ipAddress.Address6 : ipAddress.Address4;
+        let address = new ipAddressType(cidr);
+        list.push(this.formatIP(address, options));
+      } else {
+        list.push(`${all[0]}/${mask}`);
+      }
+
+      all.splice(0, decimal);
+    }
+
+    return list;
+  }
+
   arrayAction(fn, options, results) {
     options = options || {};
 
@@ -91,7 +133,7 @@ class IPCIDR {
     let length = end.subtract(start).add(new BigInteger('1'));
     let info = this.getChunkInfo(length, options);
 
-    if(results)  {
+    if (results) {
       Object.assign(results, info);
     }
 
@@ -108,8 +150,8 @@ class IPCIDR {
   getChunkInfo(length, options) {
     let from, limit, to, maxLength;
 
-    if(options.from !== undefined) {
-      if(typeof options.from != 'object') {
+    if (options.from !== undefined) {
+      if (typeof options.from != 'object') {
         from = new BigInteger(options.from + '');
       }
     }
@@ -117,8 +159,8 @@ class IPCIDR {
       from = new BigInteger('0');
     }
 
-    if(options.limit !== undefined) {
-      if(typeof options.limit != 'object') {
+    if (options.limit !== undefined) {
+      if (typeof options.limit != 'object') {
         limit = new BigInteger(options.limit + '');
       }
     }
@@ -127,11 +169,11 @@ class IPCIDR {
     }
 
     maxLength = length.subtract(from);
-    
-    if(limit.compareTo(maxLength) > 0) {
+
+    if (limit.compareTo(maxLength) > 0) {
       limit = maxLength;
     }
-    
+
     to = from.add(limit);
 
     return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ip-cidr",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,10 @@ you can get an information by chunks using options.from and options.limit
 this options might be an integer or a big integer("jsbn" instance)  
 you can pass the second argument "results" (object) to get all chunk pagination information
 
+## .toRefactoredArray([allowed], [options])
+get an array of all ip in CIDR range, refactored into the least amount of blocks defined by allowed.
+example: AWS WAF only allows `[8,16,24,32]`, using this function you can convert `x.x.x.x/20` into 16 `x.x.x.x/24` CIDR Ranges
+
 ### .arrayAction(fn, [options], [results])  
 run fn for every element of CIDR range  
 you can use the same chunk options as in .toArray

--- a/test/test.js
+++ b/test/test.js
@@ -21,6 +21,27 @@ let validRange = [
 
 let invalidCIDR = 'invalid';
 
+let validCIDRRefactor = '5.5.5.0/20';
+let allowedRefactored = [8,16,24,32];
+let validRefactored = [
+  '5.5.0.0/24', // Note the .0.0, Is this a special case? Other IPs don't cause this.
+  '5.5.1.0/24',
+  '5.5.2.0/24',
+  '5.5.3.0/24',
+  '5.5.4.0/24',
+  '5.5.5.0/24',
+  '5.5.6.0/24',
+  '5.5.7.0/24',
+  '5.5.8.0/24',
+  '5.5.9.0/24',
+  '5.5.10.0/24',
+  '5.5.11.0/24',
+  '5.5.12.0/24',
+  '5.5.13.0/24',
+  '5.5.14.0/24',
+  '5.5.15.0/24'
+];
+
 describe('IPCIDR:', function () {
   describe('check validity:', function () {
     it('should be valid', function () {
@@ -106,10 +127,19 @@ describe('IPCIDR:', function () {
       let options = {from: 3, limit: 10 };
 
       let array = cidr.toArray(options, results);
-      
+
       assert.equal(results.from.intValue(), options.from);
       assert.equal(results.to.intValue(), results.length.intValue());
       assert.equal(array.length, 5);
+    });
+  });
+
+  describe("#toRefactoredArray()", function () {
+    it('should return the expanded array of smaller cidr', function () {
+      let cidr = new IPCIDR(validCIDRRefactor);
+      let array = cidr.toRefactoredArray(allowedRefactored, {});
+
+      assert.equal(JSON.stringify(array), JSON.stringify(validRefactored));
     });
   });
 


### PR DESCRIPTION
Use Case: AWS WAF only allows these sunset masks `[8,16,24,32]`, using this function you can convert `x.x.x.x/20` into 16 `x.x.x.x/24` CIDR Ranges.

I'm open to renaming the function to reduce confusion.