### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,9 +33,9 @@ declare namespace IPCIDR {
 
   interface FormatOptions {
     type: "bigInteger" | "addressObject",
-    from: string | number | BigInteger;
-    to: string | number | BigInteger;
-    limit: number | BigInteger;
+    from?: string | number | BigInteger;
+    to?: string | number | BigInteger;
+    limit?: number | BigInteger;
   }
 
   interface ChunkInfo {


### PR DESCRIPTION
Typescript does not compile following 

```
cidr.loop(ip => console.log(ip), { type: "addressObject" });

```

This PR change updates the type declaration to make  `from`, `to`, `limit` pram optional. 