### PR TITLE
Update node minimum version to satisfy ip-address

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "url": "https://github.com/ortexx/ip-cidr"
   },
   "engines": {
-    "node": ">=5.0.0"
+    "node": ">=10.0.0"
   }
 }


### PR DESCRIPTION
When I attempted to install on a machine running Node v8, I got the following:

`npm WARN notsup Unsupported engine for ip-address@7.1.0: wanted: {"node":">= 10"} (current: {"node":"8.17.0","npm":"6.13.4"})
npm WARN notsup Not compatible with your version of node/npm: ip-address@7.1.0`

It looks like even though your package supports Node version >=5.0.0, your dependency ip-address@7.1.0 requires Node version >=10.0.0. In addition to the change I suggested, you may want to manage your published versions of your package so the right one is installed for the right Node version.