### PR TITLE
fix: use `export default` syntax in type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,4 +54,4 @@ declare namespace IPCIDR {
   export function createAddress(address: string): Address;
 }
 
-export = IPCIDR;
+export default IPCIDR;


### PR DESCRIPTION
The `export =` syntax is inappropriate for ES modules, so I have changed it to use the `export default` syntax.